### PR TITLE
perf(chromExtract): avoid re-validating backend when matching chromData

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Chromatograms
 Title: Infrastructure for Chromatographic Mass Spectrometry Data
-Version: 1.3.2
+Version: 1.3.3
 Description: The Chromatograms packages defines an efficient infrastructure
    for storing and handling of chromatographic mass spectrometry data. It
    provides different implementations of *backends* to store and represent the

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Changes in 1.3.3
 
-- Major `ChromBackendSpectra` performance improvement: `chromExtract()`,
+- Major `ChromBackendSpectra` performance improvements: `chromExtract()`,
   `Chromatograms(spectra)`, `peaksData()` and `[` no longer re-validate the
   wrapped `Spectra` on every call (which re-stated every backing file), so they
   no longer scale with the number of files.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # Version 1.3
 
+## Changes in 1.3.3
+
+- Improve `chromExtract()` performance: `.match_chromdata_peaktable()` now
+  subsets the matched `chromData` directly instead of the whole backend. This
+  avoids re-validating the backend on every call (which, for
+  `ChromBackendSpectra`, re-stated every backing file via the `Spectra`
+  validity), so `chromExtract()` no longer scales with the number of files.
+
 ## Changes in 1.3.2
 
 - Change `plotChromatograms()` and `plotChromatogramsOverlay()` to methods.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,11 +2,13 @@
 
 ## Changes in 1.3.3
 
-- Improve `chromExtract()` performance: `.match_chromdata_peaktable()` now
-  subsets the matched `chromData` directly instead of the whole backend. This
-  avoids re-validating the backend on every call (which, for
-  `ChromBackendSpectra`, re-stated every backing file via the `Spectra`
-  validity), so `chromExtract()` no longer scales with the number of files.
+- Major `ChromBackendSpectra` performance improvement: `chromExtract()`,
+  `Chromatograms(spectra)`, `peaksData()` and `[` no longer re-validate the
+  wrapped `Spectra` on every call (which re-stated every backing file), so they
+  no longer scale with the number of files.
+
+- Order `dataOrigin` by first appearance when computing the spectra sort index,
+  consistent with `backendParallelFactor()`.
 
 ## Changes in 1.3.2
 

--- a/R/ChromBackendMemory.R
+++ b/R/ChromBackendMemory.R
@@ -343,7 +343,7 @@ setMethod("chromExtract", "ChromBackendMemory", function(object, peak.table, by)
         peak.table = peak.table,
         by = by
     )
-    object <- matched$object
+    object <- object[matched$keep_idx]
     chrom_keys <- matched$chrom_keys
     peak_keys  <- matched$peak_keys
     obj_sp <- split(object, chrom_keys) ##  UT need to check that

--- a/R/ChromBackendMzR.R
+++ b/R/ChromBackendMzR.R
@@ -199,7 +199,7 @@ setMethod(
             by = by, required_cols = required_cols)
         matched <- .match_chromdata_peaktable(
             object = object, peak.table = peak.table, by = by)
-        cd <- .chromData(matched$object)
+        cd <- matched$cd
         chrom_keys <- matched$chrom_keys
         peak_keys <- matched$peak_keys
         cd_split <- split(cd, chrom_keys)

--- a/R/ChromBackendSpectra.R
+++ b/R/ChromBackendSpectra.R
@@ -266,6 +266,8 @@ chromSpectraIndex <- function(object) {
 }
 
 #' @rdname hidden_aliases
+#'
+#' @importFrom data.table rbindlist
 setMethod("factorize", "ChromBackendSpectra",
           function(object, factorize.by = c("msLevel", "dataOrigin"),...) {
             if (!all(factorize.by %in%
@@ -273,9 +275,8 @@ setMethod("factorize", "ChromBackendSpectra",
                   stop("All 'factorize.by' variables must be in the ",
                        "Spectra object.")
             spectra_f <- interaction(as.list(
-               spectraData(.spectra(object))[,
-                                            factorize.by, drop = FALSE]),
-               drop = TRUE, sep = "_")
+                spectraData(.spectra(object), columns = factorize.by)),
+                drop = TRUE, sep = "_")
             cd <- .chromData(object)
 
             if (nrow(cd)) {
@@ -283,8 +284,8 @@ setMethod("factorize", "ChromBackendSpectra",
                 if (!all(factorize.by %in% chromVariables(object)))
                     stop("All 'factorize.by' variables must be in chromData.")
                 cd$chromSpectraIndex <- interaction(cd[, factorize.by,
-                                                        drop = FALSE],
-                                                     drop = TRUE, sep = "_")
+                                                       drop = FALSE],
+                                                    drop = TRUE, sep = "_")
                 object@spectra <- .set_spectra_var(
                     object@spectra, "chromSpectraIndex",
                     factor(as.character(spectra_f),
@@ -302,11 +303,12 @@ setMethod("factorize", "ChromBackendSpectra",
                                                           sorted_spectra_f)
             } else {
                 ## chromData is empty: create it from spectra
-                object@spectra <- .set_spectra_var(object@spectra,
-                                                   "chromSpectraIndex", spectra_f)
-                full_sp <- do.call(rbindFill,
-                                   lapply(split(.spectra(object), spectra_f),
-                                          .spectra_format_chromData))
+                object@spectra <- .set_spectra_var(
+                    object@spectra, "chromSpectraIndex", spectra_f)
+                full_sp <- rbindlist(
+                    lapply(split(.spectra(object), spectra_f),
+                           .spectra_format_chromData),
+                    use.names = TRUE, fill = TRUE)
                 rownames(full_sp) <- NULL
                 object@chromData <- full_sp
             }

--- a/R/ChromBackendSpectra.R
+++ b/R/ChromBackendSpectra.R
@@ -213,7 +213,8 @@ setMethod("backendInitialize", "ChromBackendSpectra",
               ## This allows us to keep disk-backed backends intact.
               ## Only store sort index if data is actually unsorted (optimization).
               sort_idx <- order(
-                  spectra$dataOrigin,
+                  factor(spectra$dataOrigin,
+                         levels = unique(spectra$dataOrigin)),
                   spectra$rtime
               )
               if (!identical(sort_idx, seq_along(spectra))) {
@@ -251,6 +252,19 @@ chromSpectraIndex <- function(object) {
     cd
 }
 
+#' Set a spectra variable on the wrapped `Spectra` without triggering its
+#' `validObject`, which for file-backed backends re-stats every file via the
+#' `MsBackendMzR` validity. Writes directly to the backend `spectraData` slot
+#' when present; otherwise falls back to the validating `$<-`.
+#' @noRd
+.set_spectra_var <- function(s, name, value) {
+    if ("spectraData" %in% methods::slotNames(s@backend)) {
+        s@backend@spectraData[[name]] <- value
+        return(s)
+    }
+    do.call("$<-", list(s, name, value))
+}
+
 #' @rdname hidden_aliases
 setMethod("factorize", "ChromBackendSpectra",
           function(object, factorize.by = c("msLevel", "dataOrigin"),...) {
@@ -271,8 +285,10 @@ setMethod("factorize", "ChromBackendSpectra",
                 cd$chromSpectraIndex <- interaction(cd[, factorize.by,
                                                         drop = FALSE],
                                                      drop = TRUE, sep = "_")
-                object@spectra$chromSpectraIndex <- factor(as.character(spectra_f),
-                                                           levels = levels(cd$chromSpectraIndex))
+                object@spectra <- .set_spectra_var(
+                    object@spectra, "chromSpectraIndex",
+                    factor(as.character(spectra_f),
+                           levels = levels(cd$chromSpectraIndex)))
                 ## Apply sort index for processing if needed
                 if (length(object@spectraSortIndex)) {
                     sorted_spectra <- .spectra(object)[object@spectraSortIndex]
@@ -286,7 +302,8 @@ setMethod("factorize", "ChromBackendSpectra",
                                                           sorted_spectra_f)
             } else {
                 ## chromData is empty: create it from spectra
-                object@spectra$chromSpectraIndex <- spectra_f
+                object@spectra <- .set_spectra_var(object@spectra,
+                                                   "chromSpectraIndex", spectra_f)
                 full_sp <- do.call(rbindFill,
                                    lapply(split(.spectra(object), spectra_f),
                                           .spectra_format_chromData))
@@ -295,7 +312,8 @@ setMethod("factorize", "ChromBackendSpectra",
             }
             ## Recalculate sort index: only store if data is unsorted (optimization)
             sort_idx <- order(
-                object@spectra$dataOrigin,
+                factor(object@spectra$dataOrigin,
+                       levels = unique(object@spectra$dataOrigin)),
                 object@spectra$rtime
             )
             if (!identical(sort_idx, seq_along(object@spectra))) {
@@ -342,10 +360,9 @@ setMethod(
         }
         current_vals <- as.character(sorted_spectra$chromSpectraIndex)
         if (!setequal(unique(current_vals), levels(valid_f))) {
-            sorted_spectra$chromSpectraIndex <- factor(
-                current_vals,
-                levels = levels(valid_f)
-            )
+            sorted_spectra <- .set_spectra_var(
+                sorted_spectra, "chromSpectraIndex",
+                factor(current_vals, levels = levels(valid_f)))
         }
         ## Track original row indices to restore order after split/mapply
         ## split() groups by factor levels, which may reorder the data
@@ -443,7 +460,8 @@ setMethod("[", "ChromBackendSpectra", function(x, i, j, ...) {
     }
 
     x@chromData$chromSpectraIndex <- droplevels(x@chromData$chromSpectraIndex)
-    x@spectra$chromSpectraIndex <- droplevels(x@spectra$chromSpectraIndex)
+    x@spectra <- .set_spectra_var(x@spectra, "chromSpectraIndex",
+                                  droplevels(x@spectra$chromSpectraIndex))
     x
 })
 

--- a/R/ChromBackendSpectra.R
+++ b/R/ChromBackendSpectra.R
@@ -305,10 +305,10 @@ setMethod("factorize", "ChromBackendSpectra",
                 ## chromData is empty: create it from spectra
                 object@spectra <- .set_spectra_var(
                     object@spectra, "chromSpectraIndex", spectra_f)
-                full_sp <- rbindlist(
+                full_sp <- as.data.frame(rbindlist(
                     lapply(split(.spectra(object), spectra_f),
                            .spectra_format_chromData),
-                    use.names = TRUE, fill = TRUE)
+                    use.names = TRUE, fill = TRUE))
                 rownames(full_sp) <- NULL
                 object@chromData <- full_sp
             }

--- a/R/ChromBackendSpectra.R
+++ b/R/ChromBackendSpectra.R
@@ -462,7 +462,7 @@ setMethod("chromExtract", "ChromBackendSpectra",
                   peak.table = peak.table,
                   by = by
               )
-              cd <- .chromData(matched$object)
+              cd <- matched$cd
               chrom_keys <- matched$chrom_keys
               peak_keys  <- matched$peak_keys
               cd_split <- split(cd, chrom_keys) ##  UT need to check that

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -681,12 +681,8 @@
              paste(missing_keys, collapse = ", "))
     }
 
-    ## Keep only the chromData rows matched by the peak table. Subsetting the
-    ## data.frame is all that is needed here: callers that also need the spectra
-    ## or peaks re-subset the backend themselves from `keep_idx`. Subsetting the
-    ## whole backend at this point would needlessly re-validate it (for
-    ## ChromBackendSpectra that re-stats every backing file via the Spectra
-    ## validity), which is pure overhead when only the chromData is used.
+    ## Subset the matched chromData only; callers re-subset the backend from
+    ## `keep_idx`. Avoids re-validating the whole backend here.
     keep_idx <- chrom_keys %in% peak_keys
     cd <- cd[keep_idx, , drop = FALSE]
     chrom_keys <- droplevels(chrom_keys[keep_idx])

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -681,9 +681,14 @@
              paste(missing_keys, collapse = ", "))
     }
 
-    ## Subset chromdata and only keep the row of interest.
+    ## Keep only the chromData rows matched by the peak table. Subsetting the
+    ## data.frame is all that is needed here: callers that also need the spectra
+    ## or peaks re-subset the backend themselves from `keep_idx`. Subsetting the
+    ## whole backend at this point would needlessly re-validate it (for
+    ## ChromBackendSpectra that re-stats every backing file via the Spectra
+    ## validity), which is pure overhead when only the chromData is used.
     keep_idx <- chrom_keys %in% peak_keys
-    object <- object[keep_idx]
+    cd <- cd[keep_idx, , drop = FALSE]
     chrom_keys <- droplevels(chrom_keys[keep_idx])
 
     # align factor levels (so splitting matches between cd and peak.table)
@@ -691,7 +696,8 @@
     chrom_keys <- factor(as.character(chrom_keys), levels = shared_levels)
     peak_keys  <- factor(as.character(peak_keys),  levels = shared_levels)
 
-    list(object = object, chrom_keys = chrom_keys, peak_keys = peak_keys)
+    list(cd = cd, keep_idx = keep_idx,
+         chrom_keys = chrom_keys, peak_keys = peak_keys)
 }
 
 #' Used in:

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -580,27 +580,26 @@
 #' - `backendInitialize()` for `ChrombackendSpectra`
 #' @noRd
 .spectra_format_chromData <- function(sps) {
-    res <- data.frame(
-        msLevel = unique(sps$msLevel),
-        rtMin = min(sps$rtime, na.rm = TRUE),
-        rtMax = max(sps$rtime, na.rm = TRUE),
+    sv <- intersect(
+        spectraVariables(sps), c("msLevel", "rtime", "dataOrigin", "polarity",
+                                 "scanWindowLowerMz", "scanWindowUpperMz",
+                                 "chromSpectraIndex"))
+    s <- spectraData(sps, sv)
+    data.frame(
+        msLevel = unique(s$msLevel),
+        rtMin = min(s$rtime, na.rm = TRUE),
+        rtMax = max(s$rtime, na.rm = TRUE),
         mzMin = -Inf,
         mzMax = Inf,
         mz = Inf,
-        dataOrigin = unique(sps$dataOrigin),
-        chromSpectraIndex = unique(sps$chromSpectraIndex)
+        dataOrigin = unique(s$dataOrigin),
+        chromSpectraIndex = unique(s$chromSpectraIndex),
+        polarity = s$polarity[1L],
+        scanWindowLowerLimit = ifelse("scanWindowLowerLimit" %in% sv,
+                                      s$scanWindowLowerLimit[1L], NA_real_),
+        scanWindowUpperLimit = ifelse("scanWindowUpperLimit" %in% sv,
+                                      s$scanWindowUpperLimit[1L], NA_real_)
     )
-    ## Add optional columns if present
-    if ("polarity" %in% spectraVariables(sps)) {
-        res$polarity <- sps$polarity[1]
-    }
-    if ("scanWindowLowerLimit" %in% spectraVariables(sps)) {
-        res$scanWindowLowerLimit <- sps$scanWindowLowerLimit[1]
-    }
-    if ("scanWindowUpperLimit" %in% spectraVariables(sps)) {
-        res$scanWindowUpperLimit <- sps$scanWindowUpperLimit[1]
-    }
-    res
 }
 
 #' Used in:
@@ -1059,4 +1058,3 @@
     }
     c(unname(rtime[left_idx]), unname(rtime[right_idx]))
 }
-

--- a/tests/testthat/test_ChromBackendSpectra.R
+++ b/tests/testthat/test_ChromBackendSpectra.R
@@ -221,16 +221,18 @@ test_that("spectraSortIndex is set for unsorted data with multiple dataOrigins",
     cb <- ChromBackendSpectra()
     cb <- backendInitialize(cb, spectra = sp)
 
-    ## For unsorted data, spectraSortIndex should be set
+    ## For unsorted data, spectraSortIndex should be set. dataOrigin groups are
+    ## ordered by first appearance ("B" before "A"), then by rtime within group.
     expect_true(length(cb@spectraSortIndex) > 0)
-    expected_sort <- order(sp$dataOrigin, sp$rtime)
+    expected_sort <- order(factor(sp$dataOrigin, levels = unique(sp$dataOrigin)),
+                           sp$rtime)
     expect_identical(cb@spectraSortIndex, expected_sort)
 
     ## Verify sorting is correct
     sorted_do <- sp$dataOrigin[cb@spectraSortIndex]
     sorted_rt <- sp$rtime[cb@spectraSortIndex]
-    expect_identical(sorted_do, c("A", "A", "A", "B", "B", "B"))
-    expect_identical(sorted_rt, c(1, 2, 4, 3, 5, 6))
+    expect_identical(sorted_do, c("B", "B", "B", "A", "A", "A"))
+    expect_identical(sorted_rt, c(3, 5, 6, 1, 2, 4))
 })
 
 test_that("factorize() clears spectraSortIndex when data is sorted", {
@@ -378,8 +380,9 @@ test_that("[ maintains spectra and spectraSortIndex", {
     # spectraSortIndex should be set since data is unsorted
     expect_true(length(cb@spectraSortIndex) > 0)
 
-    # Verify spectraSortIndex is correctly set
-    expected_sort <- order(sp$dataOrigin, sp$rtime)
+    # Verify spectraSortIndex is correctly set (groups by first appearance)
+    expected_sort <- order(factor(sp$dataOrigin, levels = unique(sp$dataOrigin)),
+                           sp$rtime)
     expect_identical(cb@spectraSortIndex, expected_sort)
 
     # Get chromSpectraIndex before subsetting

--- a/tests/testthat/test_helpers.R
+++ b/tests/testthat/test_helpers.R
@@ -494,9 +494,9 @@ test_that(".match_chromdata_peaktable aligns correctly", {
     by = c("msLevel", "dataOrigin")
   )
 
-  # Expect a subset of object
-  expect_s4_class(matched$object, "ChromBackendMemory")
-  expect_equal(length(matched$chrom_keys), nrow(.chromData(matched$object)))
+  # Expect the matched (subsetted) chromData
+  expect_s3_class(matched$cd, "data.frame")
+  expect_equal(length(matched$chrom_keys), nrow(matched$cd))
 
   # Check factor levels alignment
   expect_true(all(levels(matched$peak_keys) %in% levels(matched$chrom_keys)))


### PR DESCRIPTION
for read-only backend we used to subset the ChromBackend object which was not necessary as chromExtract() on these backend is mostly metadata work. So instead we only subset the chromData. 