### PR TITLE
Additional performance improvements for ChromBackendSpectra

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Changes in 1.3.3
 
-- Major `ChromBackendSpectra` performance improvement: `chromExtract()`,
+- Major `ChromBackendSpectra` performance improvements: `chromExtract()`,
   `Chromatograms(spectra)`, `peaksData()` and `[` no longer re-validate the
   wrapped `Spectra` on every call (which re-stated every backing file), so they
   no longer scale with the number of files.

--- a/R/ChromBackendSpectra.R
+++ b/R/ChromBackendSpectra.R
@@ -266,6 +266,8 @@ chromSpectraIndex <- function(object) {
 }
 
 #' @rdname hidden_aliases
+#'
+#' @importFrom data.table rbindlist
 setMethod("factorize", "ChromBackendSpectra",
           function(object, factorize.by = c("msLevel", "dataOrigin"),...) {
             if (!all(factorize.by %in%
@@ -273,9 +275,8 @@ setMethod("factorize", "ChromBackendSpectra",
                   stop("All 'factorize.by' variables must be in the ",
                        "Spectra object.")
             spectra_f <- interaction(as.list(
-               spectraData(.spectra(object))[,
-                                            factorize.by, drop = FALSE]),
-               drop = TRUE, sep = "_")
+                spectraData(.spectra(object), columns = factorize.by)),
+                drop = TRUE, sep = "_")
             cd <- .chromData(object)
 
             if (nrow(cd)) {
@@ -283,8 +284,8 @@ setMethod("factorize", "ChromBackendSpectra",
                 if (!all(factorize.by %in% chromVariables(object)))
                     stop("All 'factorize.by' variables must be in chromData.")
                 cd$chromSpectraIndex <- interaction(cd[, factorize.by,
-                                                        drop = FALSE],
-                                                     drop = TRUE, sep = "_")
+                                                       drop = FALSE],
+                                                    drop = TRUE, sep = "_")
                 object@spectra <- .set_spectra_var(
                     object@spectra, "chromSpectraIndex",
                     factor(as.character(spectra_f),
@@ -302,11 +303,12 @@ setMethod("factorize", "ChromBackendSpectra",
                                                           sorted_spectra_f)
             } else {
                 ## chromData is empty: create it from spectra
-                object@spectra <- .set_spectra_var(object@spectra,
-                                                   "chromSpectraIndex", spectra_f)
-                full_sp <- do.call(rbindFill,
-                                   lapply(split(.spectra(object), spectra_f),
-                                          .spectra_format_chromData))
+                object@spectra <- .set_spectra_var(
+                    object@spectra, "chromSpectraIndex", spectra_f)
+                full_sp <- rbindlist(
+                    lapply(split(.spectra(object), spectra_f),
+                           .spectra_format_chromData),
+                    use.names = TRUE, fill = TRUE)
                 rownames(full_sp) <- NULL
                 object@chromData <- full_sp
             }

--- a/R/ChromBackendSpectra.R
+++ b/R/ChromBackendSpectra.R
@@ -305,10 +305,10 @@ setMethod("factorize", "ChromBackendSpectra",
                 ## chromData is empty: create it from spectra
                 object@spectra <- .set_spectra_var(
                     object@spectra, "chromSpectraIndex", spectra_f)
-                full_sp <- rbindlist(
+                full_sp <- as.data.frame(rbindlist(
                     lapply(split(.spectra(object), spectra_f),
                            .spectra_format_chromData),
-                    use.names = TRUE, fill = TRUE)
+                    use.names = TRUE, fill = TRUE))
                 rownames(full_sp) <- NULL
                 object@chromData <- full_sp
             }

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -580,27 +580,26 @@
 #' - `backendInitialize()` for `ChrombackendSpectra`
 #' @noRd
 .spectra_format_chromData <- function(sps) {
-    res <- data.frame(
-        msLevel = unique(sps$msLevel),
-        rtMin = min(sps$rtime, na.rm = TRUE),
-        rtMax = max(sps$rtime, na.rm = TRUE),
+    sv <- intersect(
+        spectraVariables(sps), c("msLevel", "rtime", "dataOrigin", "polarity",
+                                 "scanWindowLowerMz", "scanWindowUpperMz",
+                                 "chromSpectraIndex"))
+    s <- spectraData(sps, sv)
+    data.frame(
+        msLevel = unique(s$msLevel),
+        rtMin = min(s$rtime, na.rm = TRUE),
+        rtMax = max(s$rtime, na.rm = TRUE),
         mzMin = -Inf,
         mzMax = Inf,
         mz = Inf,
-        dataOrigin = unique(sps$dataOrigin),
-        chromSpectraIndex = unique(sps$chromSpectraIndex)
+        dataOrigin = unique(s$dataOrigin),
+        chromSpectraIndex = unique(s$chromSpectraIndex),
+        polarity = s$polarity[1L],
+        scanWindowLowerLimit = ifelse("scanWindowLowerLimit" %in% sv,
+                                      s$scanWindowLowerLimit[1L], NA_real_),
+        scanWindowUpperLimit = ifelse("scanWindowUpperLimit" %in% sv,
+                                      s$scanWindowUpperLimit[1L], NA_real_)
     )
-    ## Add optional columns if present
-    if ("polarity" %in% spectraVariables(sps)) {
-        res$polarity <- sps$polarity[1]
-    }
-    if ("scanWindowLowerLimit" %in% spectraVariables(sps)) {
-        res$scanWindowLowerLimit <- sps$scanWindowLowerLimit[1]
-    }
-    if ("scanWindowUpperLimit" %in% spectraVariables(sps)) {
-        res$scanWindowUpperLimit <- sps$scanWindowUpperLimit[1]
-    }
-    res
 }
 
 #' Used in:
@@ -1059,4 +1058,3 @@
     }
     c(unname(rtime[left_idx]), unname(rtime[right_idx]))
 }
-


### PR DESCRIPTION
- Avoid repeated extraction of spectra variables from a `Spectra` object
- Use `data.table::rbindlist()` instead of `MsCoreUtils::rbindFill()` for `data.frame` concatenation.